### PR TITLE
add proxy keys to config

### DIFF
--- a/src/config_avs.json
+++ b/src/config_avs.json
@@ -6,5 +6,11 @@
   "staticIpNetworkDetails": {
     "networkForApplianceVM": "",
     "networkCIDRForApplianceVM": ""
+  },
+  "proxyDetails": {
+    "http": "",
+    "https": "",
+    "noProxy": "",
+    "certificateFilePath": ""
   }
 }


### PR DESCRIPTION
Proxy input conversion is already supported. 
Reference: https://github.com/Azure/ArcOnAVS/blob/e16112d28d4dac1e7f284bb5f8364b34e663ef84/src/appliance_setup/pkgs/_appliance_setup.py#L23

We just need to expose the corresponding structure in user config.